### PR TITLE
Add an IAM role to bastion host

### DIFF
--- a/stacker_blueprints/bastion.py
+++ b/stacker_blueprints/bastion.py
@@ -7,7 +7,7 @@
 # the VPC you must first SSH to a bastion host, and then SSH from that host to
 # another inside the VPC.
 
-from troposphere import Ref, ec2, autoscaling, FindInMap
+from troposphere import Ref, Output, ec2, autoscaling, FindInMap
 from troposphere.autoscaling import Tag as ASTag
 from troposphere.iam import Role, InstanceProfile
 

--- a/stacker_blueprints/bastion.py
+++ b/stacker_blueprints/bastion.py
@@ -9,7 +9,7 @@
 
 from troposphere import Ref, ec2, autoscaling, FindInMap
 from troposphere.autoscaling import Tag as ASTag
-from troposphere.iam import Role, InstanceProfile, ManagedPolicyArns
+from troposphere.iam import Role, InstanceProfile
 
 from awacs.helpers.trust import get_default_assumerole_policy
 

--- a/stacker_blueprints/bastion.py
+++ b/stacker_blueprints/bastion.py
@@ -90,7 +90,7 @@ class Bastion(Blueprint):
             autoscaling.LaunchConfiguration(
                 'BastionLaunchConfig',
                 AssociatePublicIpAddress=True,
-                IAMRole=Ref("EmpireBastionRole"),
+                IamInstanceProfile=Ref("EmpireBastionProfile"),
                 ImageId=FindInMap(
                     'AmiMap',
                     FindInMap(


### PR DESCRIPTION
Add an IAM role to bastion host to allow SSM inventory.