### PR TITLE
Reduce permissions for SSM

### DIFF
--- a/stacker_blueprints/empire/controller.py
+++ b/stacker_blueprints/empire/controller.py
@@ -142,7 +142,7 @@ class EmpireController(EmpireBase):
                 AssumeRolePolicyDocument=get_default_assumerole_policy(),
                 Path="/",
                 Policies=self.generate_iam_policies(),
-                ManagedPolicyArns=["arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"]
+                ManagedPolicyArns=["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
             ))
 
         t.add_resource(

--- a/stacker_blueprints/empire/minion.py
+++ b/stacker_blueprints/empire/minion.py
@@ -245,7 +245,7 @@ class EmpireMinion(EmpireBase):
                 AssumeRolePolicyDocument=ec2_role_policy,
                 Path="/",
                 Policies=self.generate_iam_policies(),
-                ManagedPolicyArns=["arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"]
+                ManagedPolicyArns=["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
             ))
         t.add_resource(
             InstanceProfile(


### PR DESCRIPTION
In the wake of the CapitalOne breach, AWS has released reduced permissions for SSM agents on ec2 instances.