### PR TITLE
Add ecs.TagResource permissions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,3 +2,5 @@ stacker_blueprints
 ==================
 
 Blueprints for use with stacker - an attempt at a common library.
+
+After making changes to this repo, update the commit hash at https://github.com/textioHQ/empire-foundation/blob/main/empire/Pipfile#L11 to get those changes to be picked up by our forked version of Empire. See https://textio.atlassian.net/wiki/spaces/EN/pages/2563178513/Making+changes+to+our+forked+version+of+Empire for more context and instructions.

--- a/stacker_blueprints/empire/policies.py
+++ b/stacker_blueprints/empire/policies.py
@@ -45,6 +45,7 @@ def ecs_agent_policy():
                     ecs.RegisterContainerInstance,
                     ecs.DeregisterContainerInstance,
                     ecs.DiscoverPollEndpoint,
+                    ecs.TagResource,
                     ecs.Action("Submit*"),
                     ecs.Poll,
                     ecs.Action("StartTelemetrySession")]),
@@ -158,7 +159,7 @@ def empire_policy(resources):
                         ecs.Action("Describe*"), ecs.Action("List*"),
                         ecs.RegisterTaskDefinition, ecs.RunTask,
                         ecs.StartTask, ecs.StopTask, ecs.SubmitTaskStateChange,
-                        ecs.UpdateService]),
+                        ecs.TagResource, ecs.UpdateService]),
             Statement(
                 Effect=Allow,
                 # TODO: Limit to specific ELB?


### PR DESCRIPTION
## Context and changes
Updating this repo appears to be the [first step necessary](https://textio.atlassian.net/wiki/spaces/EN/pages/2563178513/Making+changes+to+our+forked+version+of+Empire#Permission-changes) to update the permissions of whatever IAM entity is responsible for [Empire](https://textio.atlassian.net/wiki/spaces/EN/blog/2019/05/09/889061577/An+attempt+to+Demystify+the+Empire) deploys (i.e., ECS deploys of all our empire-hosted services like scoring service).

The next step will be to update the [commit hash referenced in the empire-foundation Pipfile](https://github.com/textioHQ/empire-foundation/blob/main/empire/Pipfile#L11), so the new policies will get pulled in to deploys. See the [Confluence page](https://textio.atlassian.net/wiki/spaces/EN/pages/2563178513/Making+changes+to+our+forked+version+of+Empire#Permission-changes) for full context.

## Testing
The [actual test command](https://github.com/textioHQ/stacker_blueprints/blob/master/Makefile#L3) in `make test` fails with `Failed building wheel for PyYAML`, but linting at least shows that there are no syntax errors, just style errors:
```
stacker_blueprints$ make test
flake8 stacker_blueprints
stacker_blueprints/bastion.py:125:80: E501 line too long (94 > 79 characters)
stacker_blueprints/empire/controller.py:145:80: E501 line too long (90 > 79 characters)
stacker_blueprints/empire/daemon.py:428:80: E501 line too long (82 > 79 characters)
stacker_blueprints/empire/minion.py:248:80: E501 line too long (90 > 79 characters)
stacker_blueprints/postgres.py:19:1: E302 expected 2 blank lines, found 1
make: *** [test] Error 1
```
I'm not sure what running the tests would get us anyway, since this is just a permissions change, so I think we should proceed without getting tests fully working.